### PR TITLE
Fix README and add default value for --format

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,7 +165,7 @@ to your command for useful debugging information.
 $./opsmtools.py --host http://my.opsmgr.server:8080 \
                --group 57598b14e4b01b9f37aadaf8 \
                --username jason.mimick@mongodb.com --apikey xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx \
-               --getAlerts
+               --getAlerts --format table
 +Alerts from http://my.opsmgr.server:8080--------------------------------+
 | eventTypeName         | status | created              | replicaSetName |
 +-----------------------+--------+----------------------+----------------+

--- a/opsmtools.py
+++ b/opsmtools.py
@@ -709,7 +709,7 @@ parser.add_argument("--continueOnError", action='store_true', default=False
 parser.add_argument("--verbose", action='store_true', default=False
         ,help='enable versbose output for troubleshooting')
 parser.add_argument("--format", default='json'
-        ,help='specify output format')
+        ,help='specify output format. Default: json')
 parser.add_argument("--alertId"
         ,help="id of alert to acknowledge")
 parser.add_argument("--ackUntil", default="XXX"


### PR DESCRIPTION
By default, json output is always selected.
Updated README in order to show how to print table